### PR TITLE
Fix build on systems with GNU Make not up to date

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,6 +1,6 @@
-DEFAULT_HOST != ../default-host.sh
-HOST ?= DEFAULT_HOST
-HOSTARCH != ../target-triplet-to-arch.sh $(HOST)
+DEFAULT_HOST = $(shell ../default-host.sh)
+HOST ?= $(DEFAULT_HOST)
+HOSTARCH = $(shell ../target-triplet-to-arch.sh $(HOST))
 
 CFLAGS ?= -O2 -g
 CPPFLAGS ?=
@@ -79,7 +79,7 @@ install: install-headers install-kernel
 
 install-headers:
 	mkdir -p $(DESTDIR)$(INCLUDEDIR)
-	cp -R --preserve=timestamps include/. $(DESTDIR)$(INCLUDEDIR)/.
+	cp -pR include/. $(DESTDIR)$(INCLUDEDIR)/.
 
 install-kernel: vault.kernel
 	mkdir -p $(DESTDIR)$(BOOTDIR)

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,6 +1,6 @@
-DEFAULT_HOST != ../default-host.sh
-HOST ?= DEFAULT_HOST
-HOSTARCH != ../target-triplet-to-arch.sh $(HOST)
+DEFAULT_HOST = $(shell ../default-host.sh)
+HOST ?= $(DEFAULT_HOST)
+HOSTARCH = $(shell ../target-triplet-to-arch.sh $(HOST))
 
 CFLAGS ?= -O2 -g
 CPPFLAGS ?=
@@ -101,7 +101,7 @@ install: install-headers install-libs
 
 install-headers:
 	mkdir -p $(DESTDIR)$(INCLUDEDIR)
-	cp -R --preserve=timestamps include/. $(DESTDIR)$(INCLUDEDIR)/.
+	cp -pR include/. $(DESTDIR)$(INCLUDEDIR)/.
 
 install-libs: $(BINARIES)
 	mkdir -p $(DESTDIR)$(LIBDIR)


### PR DESCRIPTION
Also fixes `cp` commands on Unix systems by replacing the `--preserve=timestamps` by a `-p`.